### PR TITLE
Missing keyword in help. Fix bug where error messages do not appear.

### DIFF
--- a/bin/phpqa.sh
+++ b/bin/phpqa.sh
@@ -38,7 +38,7 @@ function displayHelp()
     -x extension...................... Skipif option, specify extension to check for
     -h ............................... Print this message\n";
     printf "${_YELLOW}RUN usage${_NC}:
-    phpqa <path/to/test.phpt|suite> [<version>]\n\n";
+    phpqa run <path/to/test.phpt|suite> [<version>]\n\n";
 
     exit ${exitCode};
 }

--- a/bin/phpqa.sh
+++ b/bin/phpqa.sh
@@ -90,8 +90,9 @@ function fixRunPath()
 
 function singleTest()
 {
+    print_f "${_RUN_FILENAME}\n"
     docker run --rm -i -t \
-        -v ${_RUN_FILE_PATH}:/usr/src/phpt/${_RUN_FILENAME} herdphp/phpqa:${_RUN_VERSION} \
+        -v ${_RUN_FILE_PATH}/../:/usr/src/phpt/ herdphp/phpqa:${_RUN_VERSION} \
         make test TESTS=/usr/src/phpt/${_RUN_FILENAME} \
         | sed -e "s/Build complete./Test build successfully./" -e "s/Don't forget to run 'make test'./=\)/";
 }


### PR DESCRIPTION
First, something minor I noticed, missing word in help message, may be confusing to people relying on the message.

Second, big problem I had, If a test failed, I was not seeing any of the error files. This was because docker was mounting the file, rather than the directory, so the error files never appeared on the host machine. Mounting the directory of the test file sorted the problem out for me.

Has anyone else had this problem, or is it specific to my machine? I followed the instructions and was confused when I didn't see the files.