### PR TITLE
Improving debug output for failing tests

### DIFF
--- a/bin/phpqa.sh
+++ b/bin/phpqa.sh
@@ -86,13 +86,16 @@ function fixRunPath()
     if [[ ! "${_RUN_FILE_PATH}" = /* ]]; then
         _RUN_FILE_PATH="$(pwd)/${_RUN_FILE_PATH}";
     fi
+    _RUN_FILE_DIR=$(dirname "${_RUN_FILE_PATH}");
 }
 
 function singleTest()
 {
-    print_f "${_RUN_FILENAME}\n"
+    mkdir -p ${_RUN_FILE_DIR}/${_RUN_VERSION}/;
+    cp ${_RUN_FILE_PATH} ${_RUN_FILE_DIR}/${_RUN_VERSION}/;
     docker run --rm -i -t \
-        -v ${_RUN_FILE_PATH}/../:/usr/src/phpt/ herdphp/phpqa:${_RUN_VERSION} \
+        -v ${_RUN_FILE_DIR}/${_RUN_VERSION}/:/usr/src/phpt/ \
+        herdphp/phpqa:${_RUN_VERSION} \
         make test TESTS=/usr/src/phpt/${_RUN_FILENAME} \
         | sed -e "s/Build complete./Test build successfully./" -e "s/Don't forget to run 'make test'./=\)/";
 }

--- a/bin/phpqa.sh
+++ b/bin/phpqa.sh
@@ -48,8 +48,8 @@ function parseRunArgs()
     _RUN_FILE_PATH=$1
     _RUN_VERSION=$2;
 
-    if [ -z "${_RUN_FILE_PATH}" ] || [ ! -f "${_RUN_FILE_PATH}" ]; then
-        displayHelp "You need to provide a phpt file to be tested or pass \`suite\` as first parameter to run the full test suite.";
+    if [ -z "${_RUN_FILE_PATH}" ] || ([ ! -f "${_RUN_FILE_PATH}" ] && [ ! -d "${_RUN_FILE_PATH}" ]); then
+        displayHelp "You need to provide a phpt or a directory with phpt files to be tested or pass \`suite\` as first parameter to run the full test suite.";
     fi
 
     if [ -z "${_RUN_VERSION}" ]; then
@@ -92,7 +92,7 @@ function fixRunPath()
 function singleTest()
 {
     mkdir -p ${_RUN_FILE_DIR}/${_RUN_VERSION}/;
-    cp ${_RUN_FILE_PATH} ${_RUN_FILE_DIR}/${_RUN_VERSION}/;
+    cp -r ${_RUN_FILE_PATH} ${_RUN_FILE_DIR}/${_RUN_VERSION}/;
     docker run --rm -i -t \
         -v ${_RUN_FILE_DIR}/${_RUN_VERSION}/:/usr/src/phpt/ \
         herdphp/phpqa:${_RUN_VERSION} \


### PR DESCRIPTION
* Debug files are generated now inside a directory for the related
version. This aims to fix the issue #16 were is reported that these
debug files are being overridden when running in multiple verions;
* Fix a minor issue introduced by PR #29;
* Adding possibility to run multiple files.