### PR TITLE
Using current directory as default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 phpt/*
 !phpt/examples/*.phpt
+*.phpt

--- a/bin/phpqa.sh
+++ b/bin/phpqa.sh
@@ -130,7 +130,7 @@ function parseGenerateArgs()
     _GENERATE_VERSION=${_PHPQA_PHP_VERSION};
 
     if [ -z "${_GENERATE_DIR}" ] || [[ ${generateOptions} =~ (^|[[:space:]])${_GENERATE_DIR}($|[[:space:]]) ]]; then
-        _GENERATE_DIR="$(git rev-parse --show-toplevel)/phpt";
+        _GENERATE_DIR="$(pwd)";
         _GENERATE_ARGS=$@;
     fi
 


### PR DESCRIPTION
The phpqa generate command now uses the current directory to place .phpt
files if no target is passed. This aims to fix the issue #45 about the
same subject.