### PR TITLE
Clarifying that the Docker daemon must be running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ to create PHPT tests for PHP language engine and its core extensions.
 ````bash
 curl -s https://raw.githubusercontent.com/herdphp/docker-phpqa/master/bin/installer.sh | bash
 ````
+3. Make sure the Docker daemon is running:
+```bash
+sudo systemctl start docker
+```
 
-3. Start PHPTesting!!!
+4. Start PHPTesting!!!
 
 ## How to use it?
 


### PR DESCRIPTION
For people who aren't used to Docker it might be confusing that they can't run any tests unless the docker daemon is running.