### PR TITLE
Remove --disable-cgi to enable testing of CGI functionality

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -91,7 +91,6 @@ RUN set -xe \
 		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
-		--disable-cgi \
 		--enable-ftp \
 		--enable-mbstring \
 		--enable-mysqlnd \


### PR DESCRIPTION
I ran into this issue when trying to run tests that contain `--CGI--` or `--POST--` or other blocks requiring the use of the PHP cgi. Since `herdphp/phpqa` doesn't have the PHP cgi, it skips these tests. Removing `--disable-cgi` from the configure line and rebuilding the image allows running these tests.