### PR TITLE
Fix running update from a directory different than the project's

### DIFF
--- a/bin/phpqa.sh
+++ b/bin/phpqa.sh
@@ -4,6 +4,7 @@ _YELLOW='\033[1;33m' # yellow color
 _GREEN='\033[0;32m' # green color
 _NC='\033[0m' # no color
 
+_PHPQA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _PHPQA_PHP_VERSION=71;
 
 function displayError()
@@ -65,7 +66,9 @@ function parseRunArgs()
 function updateAll()
 {
     printf "${_YELLOW}[Update 1/2]${_NC} Updating docker-phpqa scripts...\n"
-    git pull;
+    pushd $_PHPQA_DIR
+    git pull
+    popd
     printf "${_GREEN}[Update 1/2]${_NC} Scripts updated!\n"
 
     printf "${_YELLOW}[Update 2/2]${_NC} Updating docker-phpqa Docker images...\n"


### PR DESCRIPTION
This fix adds a script directory to run `git pull` from, instead of using bash CWD.